### PR TITLE
[feat] 회원가입 엔터 등록, 닉네임 아이디에 한글 입력 방지

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,7 +1,7 @@
 import { createRouter } from './router.js';
 import createPages from './pages.js'
 
-export const SERVER_IP = '10.11.3.1';
+export const SERVER_IP = 'localhost';
 
 // 로그인 상태 확인 함수
 function checkLoginStatus() {

--- a/pages/signup/signup.js
+++ b/pages/signup/signup.js
@@ -4,6 +4,13 @@ import { SERVER_IP } from "../../js/index.js";
 
 // MainPage 클래스를 상속하는 새로운 클래스 정의
 export default class SignupPage {
+    handleEnterKey = (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.handleFormBtn(event);
+        }
+    };
+
     // render 메서드를 정의하여 HTML 콘텐츠를 반환
     render() {
         return `
@@ -92,6 +99,17 @@ export default class SignupPage {
             return;
         }
 
+        // 한글 입력 방지
+        const koreanPattern = /[ㄱ-ㅎㅏ-ㅣ가-힣]/g;
+        if (koreanPattern.test(nickname)) {
+            this.handleSignupError({ message: "닉네임에 영어를 사용할 수 없습니다." });
+            return;
+        }
+        if (koreanPattern.test(userID)) {
+            this.handleSignupError({ message: "아이디에 영어를 사용할 수 없습니다." });
+            return;
+        }
+
 
         const formData = {
             userID,
@@ -122,7 +140,7 @@ export default class SignupPage {
             } else {
                 const errorData = await response.json();
                 this.handleSignupError(errorData);
-            
+
             }
 
         } catch (error) {
@@ -160,6 +178,7 @@ export default class SignupPage {
         switch (errorData.message) {
             case "이미 존재하는 닉네임입니다.":
             case "닉네임 필드를 입력해주세요.":
+            case "닉네임에 영어를 사용할 수 없습니다.":
                 nickname_label.innerText = `${errorData.message}`;
                 nickname_label.classList.add("form-error-label");
                 nickname.classList.add("form-error");
@@ -173,6 +192,7 @@ export default class SignupPage {
                 break;
             case "이미 존재하는 아이디입니다.":
             case "아이디 필드를 입력해주세요.":
+            case "아이디에 영어를 사용할 수 없습니다.":
                 userID_label.innerText = `${errorData.message}`;
                 userID_label.classList.add("form-error-label");
                 userID.classList.add("form-error");
@@ -207,5 +227,7 @@ export default class SignupPage {
 
         const signupForm = document.getElementById('signup-form');
         signupForm.addEventListener('submit', this.handleFormBtn.bind(this));
+
+        signupForm.addEventListener('keydown', (event) => this.handleEnterKey(event));
     }
 }

--- a/pages/signup/signup.js
+++ b/pages/signup/signup.js
@@ -102,11 +102,11 @@ export default class SignupPage {
         // 한글 입력 방지
         const koreanPattern = /[ㄱ-ㅎㅏ-ㅣ가-힣]/g;
         if (koreanPattern.test(nickname)) {
-            this.handleSignupError({ message: "닉네임에 영어를 사용할 수 없습니다." });
+            this.handleSignupError({ message: "닉네임에 한글을 사용할 수 없습니다." });
             return;
         }
         if (koreanPattern.test(userID)) {
-            this.handleSignupError({ message: "아이디에 영어를 사용할 수 없습니다." });
+            this.handleSignupError({ message: "아이디에 한글을 사용할 수 없습니다." });
             return;
         }
 
@@ -178,7 +178,7 @@ export default class SignupPage {
         switch (errorData.message) {
             case "이미 존재하는 닉네임입니다.":
             case "닉네임 필드를 입력해주세요.":
-            case "닉네임에 영어를 사용할 수 없습니다.":
+            case "닉네임에 한글을 사용할 수 없습니다.":
                 nickname_label.innerText = `${errorData.message}`;
                 nickname_label.classList.add("form-error-label");
                 nickname.classList.add("form-error");
@@ -192,7 +192,7 @@ export default class SignupPage {
                 break;
             case "이미 존재하는 아이디입니다.":
             case "아이디 필드를 입력해주세요.":
-            case "아이디에 영어를 사용할 수 없습니다.":
+            case "아이디에 한글을 사용할 수 없습니다.":
                 userID_label.innerText = `${errorData.message}`;
                 userID_label.classList.add("form-error-label");
                 userID.classList.add("form-error");


### PR DESCRIPTION
- 폼 등록 후 엔터로 회원가입 가능하도록 이벤트 추가했습니다.
- 닉네임과 아이디에 한글 입력 시 "닉네임에 영어를 사용할 수 없습니다.", "아이디에 영어를 사용할 수 없습니다" 안내문 보이게 수정했습니다.