### PR TITLE
Fix: 친구추가 직후 친구초대 되지 않는 오류 해결

### DIFF
--- a/pages/friend/friend.js
+++ b/pages/friend/friend.js
@@ -170,6 +170,7 @@ export default class FriendPage {
                     }
                     const router = getRouter();
                     router.navigate('/friend');
+                    // connectNotificationWebSocket(token);
                 } catch (error) {
                     console.error('Fetch error:', error);
                 }


### PR DESCRIPTION
기존 : a가 b에게 친구추가 요청을 보낸 후 b가 수락을 한 경우, a가 b에게 게임 초대를 하려면 1. b를 새로고침 하거나 2. b가 a에게 게임 초대를 보낸 후에야 가능 했음. 2-1. b가 a에게 게임 초대 보내는 건 문제없이 됐었음.

수정: 이젠 a와 b 모두 친구 추가 직후 별도의 새로고침 없이 게임 초대 가능~