### PR TITLE
Fix: 통계페이지 이미지 불러오기

### DIFF
--- a/assets/components/rank-info/rank-info.css
+++ b/assets/components/rank-info/rank-info.css
@@ -62,3 +62,9 @@
 	height: 50%;
 	padding-left: 1%;
 }
+
+.user-rank-info-image {
+    height: auto;
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+}

--- a/assets/components/rank-info/rank-info.js
+++ b/assets/components/rank-info/rank-info.js
@@ -14,12 +14,14 @@ export function renderUserRankInfo(data, nickname) {
         Imgsrc = `assets/icons/bronz.svg`;
     }
 
-    return `
-        <div class="user-rank-info" id=${data.nickname === nickname ? "profile-user-rank-info-inAll" : ""}>
-			<span>${data.rank ? data.rank : '-'}</span>
-			<img src="assets/images/profile.svg" alt="progile_img"/>
-			<span class="user-rank-info__nickname">${data.nickname}</span>
-			<img src=${Imgsrc} alt="tier"/>
-        </div>
-    `;
+     const profileImgSrc = data.image_url ? data.image_url : 'assets/images/profile.svg';
+
+     return `
+         <div class="user-rank-info" id="${data.nickname === nickname ? "profile-user-rank-info-inAll" : ""}">
+             <span>${data.rank ? data.rank : '-'}</span>
+             <img src="${profileImgSrc}" alt="profile_img" class="user-rank-info-image"/>
+             <span class="user-rank-info__nickname">${data.nickname}</span>
+             <img src="${Imgsrc}" alt="tier"/>
+         </div>
+     `;
 }

--- a/pages/rank/rank.css
+++ b/pages/rank/rank.css
@@ -119,6 +119,8 @@
 .rank__right-section__user-info--img img{
 	width: 30%;
 	border-radius: 50%;
+	height: auto;
+    aspect-ratio: 1 / 1;
 }
 
 .rank__right-section__user-info--text {

--- a/pages/rank/rank.js
+++ b/pages/rank/rank.js
@@ -56,7 +56,7 @@ export default class RankPage {
                 <section class="rank__right-section">
                     <div class="rank__right-section__user-info">
                         <div class="rank__right-section__user-info--img">
-                            <img src="assets/images/profile.svg" alt="profile_img"/>
+                            <img src="assets/images/profile.svg" alt="profile_img" id="rank__right-section__user-image"/>
                         </div>
                         <div class="rank__right-section__user-info--text">
                             <div class="rank-star-container">
@@ -170,9 +170,16 @@ export default class RankPage {
     updateUserRankInfo(userData) {
         const rankNumberElement = document.querySelector('.rank-number');
         const nicknameElement = document.getElementById('rank-data--nickname');
-
+        // const profileImg = document.querySelector('.user-rank-info-image');
         // 유저 정보 업데이트
         nicknameElement.textContent = userData.nickname;
+
+        // if (userData.image) {
+        //     profileImg.src = userData.image;
+        // } else {
+        //     profileImg.src = "assets/images/profile.svg";  // 기본 이미지
+        // }
+
         if (!userData.rank)
             rankNumberElement.textContent = '-';
         else
@@ -215,12 +222,20 @@ export default class RankPage {
                 const data = await response.json();
                 const winRate = data.win_rate;
                 const lose_cnt = data.match_cnt - data.win_cnt;
+                const user_image = data.image;
 
                 const gameCountElement = document.querySelector('.user-dash-board__rate--text span:nth-of-type(1)');
                 const gameStateElement = document.querySelector('.user-dash-board__rate--text span:nth-of-type(2)');
+                const userImage = document.getElementById('rank__right-section__user-image');
                 gameCountElement.textContent = `${data.match_cnt}전 ${data.win_cnt}승 ${lose_cnt}패`;
                 gameStateElement.textContent = `승률 ${winRate}%`
-    
+
+                if (user_image) {
+                    userImage.src = user_image;
+                } else {
+                    userImage.src = "assets/images/profile.svg";  // 기본 이미지
+                }
+
                 // 새 차트 생성
                 this.stateChartInstance = new Chart(ctx, {
                     type: 'bar',

--- a/pages/rank/rank.js
+++ b/pages/rank/rank.js
@@ -170,15 +170,7 @@ export default class RankPage {
     updateUserRankInfo(userData) {
         const rankNumberElement = document.querySelector('.rank-number');
         const nicknameElement = document.getElementById('rank-data--nickname');
-        // const profileImg = document.querySelector('.user-rank-info-image');
-        // 유저 정보 업데이트
         nicknameElement.textContent = userData.nickname;
-
-        // if (userData.image) {
-        //     profileImg.src = userData.image;
-        // } else {
-        //     profileImg.src = "assets/images/profile.svg";  // 기본 이미지
-        // }
 
         if (!userData.rank)
             rankNumberElement.textContent = '-';


### PR DESCRIPTION
통계페이지 이미지 백엔드 연결 후 렌더링
<img width="2560" alt="Screen Shot 2024-10-17 at 10 52 46 PM" src="https://github.com/user-attachments/assets/268cac29-b4b4-4adf-99e1-871a9c5a7f96">
