### PR TITLE
fix: 온라인 게임 초대 여러번 오는 에러

### DIFF
--- a/assets/components/nav/nav.js
+++ b/assets/components/nav/nav.js
@@ -295,11 +295,15 @@ export function connectNotificationWebSocket(accessToken) {
             const myNickname = data.receiver;
             console.log("myNickname: ", myNickname);
 
+            const modalId = 'game-invite-modal'; // 모달에 고유 id를 부여
+            if (document.getElementById(modalId)) 
+                return;
             // showModal(sender+'님으로 부터 게임 초대가 왔어요!', '수락');
             const modalHTML = createModal(`${sender}님으로 부터 게임 초대가 왔어요!`, '수락');
 
             // 새 div 요소를 생성하여 모달을 페이지에 추가
             const modalDiv = document.createElement('div');
+            modalDiv.id = modalId;
             modalDiv.innerHTML = modalHTML;
             document.body.appendChild(modalDiv);
 


### PR DESCRIPTION
단순히 이미 초대장이 떠 있으면 중복으로 뜨지 않게 만든거라 웹소켓으로 초대 요청은 계속 옵니다... 최적화 하려면 백엔드 모델 수정하고 각 상황마다 모델 상태 건드려야 해서 복잡할 듯 해 일단 눈으로 볼 때 이상 없는 것 처럼 보이게 했습니다. 참고 부탁드립니다.