### PR TITLE
[Feat] 친구페이지 나머지 동작

### DIFF
--- a/assets/components/chat-room/chat-room.css
+++ b/assets/components/chat-room/chat-room.css
@@ -38,7 +38,7 @@
     margin: 1vw 5vh;
 }
 
-#delete-friend-btn, #block-friend-btn {
+#game-request-btn, #block-friend-btn {
     background-color: rgba(171, 171, 171, 0.5);
     padding: 5px 10px;
     border-radius: 15px;
@@ -51,7 +51,11 @@
     width: 5vw;
 }
 
-#delete-friend-btn:hover, #block-friend-btn:hover {
+#game-request-btn:hover {
+    background-color: rgba(110,208,135, 0.7);
+}
+
+#block-friend-btn:hover {
     background-color: rgba(171, 171, 171, 0.8);
 }
 

--- a/assets/components/chat-room/chat-room.js
+++ b/assets/components/chat-room/chat-room.js
@@ -13,7 +13,7 @@ export function createChatRoom(image, nickname, win, score) {
             </div>
         </div>
         <div class="friend-button-list">
-            <button id="delete-friend-btn">삭제</button>
+            <button id="game-request-btn">게임초대</button>
             <button id="block-friend-btn">차단</button>
         </div>
     </div>

--- a/assets/components/friend-request/friend-request.css
+++ b/assets/components/friend-request/friend-request.css
@@ -65,7 +65,7 @@
 }
 
 .request-accept-btn {
-    border: 3px solid var(--main-color);
+    /* border: 3px solid var(--main-color); */
     background-color: rgba(110, 208, 135, 0.6);
 
     width: 3.8vw;
@@ -87,7 +87,7 @@
 }
 
 .request-refuse-btn {
-    border: 3px solid var(--main-color);
+    /* border: 3px solid var(--main-color); */
     background-color: rgba(255, 137, 125, 0.7);
 
     width: 3.8vw;

--- a/assets/components/nav/nav.js
+++ b/assets/components/nav/nav.js
@@ -421,32 +421,32 @@ export function connectNotificationWebSocket(accessToken) {
                 friendStatusElement.className = `list-online-status ${activeClass}`;
             }
         }
-        else if (data.type === 'request_fr') {
-            if (window.location.pathname === '/friend') {
-                const friendReqBox = document.querySelector('.friend-request-box');
-                if (friendReqBox) {
-                    friendReqBox.innerHTML = '';
-                    const friendPageInstance = new FriendPage();
-                    friendPageInstance.updateFriendRequest(friendReqBox, "../../assets/images/profile.svg", data.sender);
-                }
-            } else{
-                hasNotification = true;
-                updateNotificationDisplay();
-            }
+        // else if (data.type === 'request_fr') {
+        //     if (window.location.pathname === '/friend') {
+        //         const friendReqBox = document.querySelector('.friend-request-box');
+        //         if (friendReqBox) {
+        //             friendReqBox.innerHTML = '';
+        //             const friendPageInstance = new FriendPage();
+        //             friendPageInstance.updateFriendRequest(friendReqBox, "../../assets/images/profile.svg", data.sender);
+        //         }
+        //     } else{
+        //         hasNotification = true;
+        //         updateNotificationDisplay();
+        //     }
 
-            const friendReq = document.querySelector('.friend-request-box');
+        //     const friendReq = document.querySelector('.friend-request-box');
 
-            if (data.tag === 'request' && friendReq) {
-                friendReq.innerHTML = '';
+        //     if (data.tag === 'request' && friendReq) {
+        //         friendReq.innerHTML = '';
 
-                const friendPageInstance = new FriendPage();
-                friendPageInstance.updateFriendRequest(friendReq, "../../assets/images/profile.svg", data.sender);
-            }
-            else if (data.tag === 'accept') {
-                const router = getRouter();
-                router.navigate('/friend');
-            }
-        }
+        //         const friendPageInstance = new FriendPage();
+        //         friendPageInstance.updateFriendRequest(friendReq, "../../assets/images/profile.svg", data.sender);
+        //     }
+        //     else if (data.tag === 'accept') {
+        //         const router = getRouter();
+        //         router.navigate('/friend');
+        //     }
+        // }
     };
 
     notificationWebSocket.onclose = () => {

--- a/pages/friend/friend.js
+++ b/pages/friend/friend.js
@@ -139,7 +139,6 @@ export default class FriendPage {
 
     // 친구 요청 확인
     async updateFriendRequest(friendReq, image, sender) {
-        console.log("sender:" + sender);
         const token = localStorage.getItem('access_token');
 
         const requestContainer = document.createElement('div');
@@ -171,7 +170,7 @@ export default class FriendPage {
             });
         }
         // 거절 버튼에 이벤트 리스너 추가
-        const refuseButton = friendReq.querySelector('.request-refuse-btn');
+        const refuseButton = requestContainer.querySelector('.request-refuse-btn');
         if (refuseButton) {
             refuseButton.addEventListener('click', async function () {
                 try {

--- a/pages/friend/friend.js
+++ b/pages/friend/friend.js
@@ -81,7 +81,6 @@ export default class FriendPage {
                     const nickname = friend.nickname;
 
                     this.updateFriendRequest(friendReq, image, nickname);
-
                 });
             } else {
                 friendReq.classList.remove('has-friend-requests');
@@ -131,7 +130,7 @@ export default class FriendPage {
             searchBtn.addEventListener('click', async () => {
                 closeChatSocket();
                 this.showUserSearchModal();
-                this.showFriendRequest();
+                // this.showFriendRequest();
             });
         } else {
             console.error('block-icon 요소를 찾을 수 없습니다.');
@@ -614,13 +613,15 @@ export default class FriendPage {
                 const friendReq = document.querySelector('.friend-request-box');
               
                 if (data.tag === 'request' && friendReq) {
-                      friendReq.innerHTML = '';
-                      this.updateFriendRequest(friendReq, "../../assets/images/profile.svg", data.sender);
-                  }
-                  else if (data.tag === 'accept') {
-                      const router = getRouter();
-                      router.navigate('/friend');
-                  }
+                    friendReq.innerHTML = '';
+                    friendReq.classList.remove('no-friend-requests');
+                    friendReq.classList.add('has-friend-requests');
+                    this.updateFriendRequest(friendReq, "../../assets/images/profile.svg", data.sender);
+                }
+                else if (data.tag === 'accept') {
+                    const router = getRouter();
+                    router.navigate('/friend');
+                }
             }
         };
 

--- a/pages/friend/friend.js
+++ b/pages/friend/friend.js
@@ -7,6 +7,7 @@ import {getRouter} from '../../../js/router.js';
 import {createModal} from '../../assets/components/modal/modal.js';
 import {SERVER_IP} from "../../js/index.js";
 import { connectNotificationWebSocket } from '../../assets/components/nav/nav.js';
+import WaitGamePage from '../waitgame/waitgame.js';
 
 let chatSocket = null;
 let notificationSocket = null;
@@ -400,6 +401,8 @@ export default class FriendPage {
         // 친구 게임 초대
         document.querySelector('#game-request-btn').addEventListener('click', async () => {
         
+            const waitGameInstance = new WaitGamePage();
+            await waitGameInstance.sendInvite(friendNickname, token);
             console.log("게임 초대 버튼 클릭")
         });
 

--- a/pages/friend/friend.js
+++ b/pages/friend/friend.js
@@ -139,6 +139,7 @@ export default class FriendPage {
 
     // 친구 요청 확인
     async updateFriendRequest(friendReq, image, sender) {
+        console.log("sender:" + sender);
         const token = localStorage.getItem('access_token');
 
         const requestContainer = document.createElement('div');
@@ -577,11 +578,11 @@ export default class FriendPage {
         });
     }
 
-    async showFriendRequest() {
-//         const friendReq = document.querySelector('.friend-request-box');
-//         const access_token = localStorage.getItem("access_token");
-//         const notificationSocket = connectNotificationWebSocket(access_token);
-      
+    // 1. 실시간 online, offline 상태 반영
+    // 2. 실시간 메시지 알림
+    // 3. 실시간 친구 요청 알림
+    async handleSocket() {
+
         const token = localStorage.getItem('access_token');
         notificationSocket = connectNotificationWebSocket(token);
 
@@ -609,47 +610,27 @@ export default class FriendPage {
                     messageStatusElement.style.display = 'inline';
                 }
             }
-            else {
-                const friendReq = document.querySelector('.friend-request-box');
-              
-                if (data.tag === 'request' && friendReq) {
-                    friendReq.innerHTML = '';
-                    friendReq.classList.remove('no-friend-requests');
-                    friendReq.classList.add('has-friend-requests');
-                    this.updateFriendRequest(friendReq, "../../assets/images/profile.svg", data.sender);
+            else if (data.type === 'request_fr') {
+                // 친구 요청 알림
+                if (data.tag === 'request') {
+                    const friendReq = document.querySelector('.friend-request-box');
+
+                    if (friendReq) {
+                        if (friendReq.innerHTML === '<p>새로운 친구 요청이 없습니다.</p>') {
+                            friendReq.innerHTML = '';
+                            friendReq.classList.remove('no-friend-requests');
+                            friendReq.classList.add('has-friend-requests');
+                        }
+                        this.updateFriendRequest(friendReq, "../../assets/images/profile.svg", data.sender);
+                    }
                 }
+                // 친구 수락 알림
                 else if (data.tag === 'accept') {
                     const router = getRouter();
                     router.navigate('/friend');
                 }
             }
         };
-
-//         if (notificationSocket.readyState === WebSocket.CONNECTING) {
-//             notificationSocket.addEventListener('open', () => {
-//                 sendMessages(notificationSocket);
-//             });
-//         } else if (notificationSocket.readyState === WebSocket.OPEN) {
-//             sendMessages(notificationSocket);
-//         }
-
-//         function sendMessages(socket) {
-//             if (friendReq) {
-//                 const getNotificationsMessage = {
-//                     type: 'get_notifications'
-//                 };
-
-//                 const statusMessage = {
-//                     type: 'notify_status_message',
-//                     status: 'online'
-//                 };
-
-//                 socket.send(JSON.stringify(getNotificationsMessage));
-//                 socket.send(JSON.stringify(statusMessage));
-
-//                 console.log('알림 요청 및 상태 메시지가 전송되었습니다.');
-//             }
-//         }
     }
 
 
@@ -756,7 +737,7 @@ export default class FriendPage {
     }
 
     async afterRender() {
-        this.showFriendRequest();
+        this.handleSocket();
         this.handlePage();
     }
 }

--- a/pages/friend/friend.js
+++ b/pages/friend/friend.js
@@ -398,25 +398,10 @@ export default class FriendPage {
             console.error('채팅 방을 불러오는 중 오류 발생:', error);
         }
 
-        // 친구 삭제
-        document.querySelector('#delete-friend-btn').addEventListener('click', async () => {
-            try {
-                const response = await fetch(`https://${SERVER_IP}/api/friend/delete/${friendNickname}/`, {
-                    method: 'POST',
-                    headers: {
-                        'Authorization': `Bearer ${token}`
-                    }
-                });
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
-                this.showModal('친구 삭제가 완료되었습니다.', '확인');
-
-                const router = getRouter();
-                router.navigate('/friend');
-            } catch (error) {
-                console.error('친구 삭제 중 오류 발생:', error);
-            }
+        // 친구 게임 초대
+        document.querySelector('#game-request-btn').addEventListener('click', async () => {
+        
+            console.log("게임 초대 버튼 클릭")
         });
 
         // 친구 차단


### PR DESCRIPTION
1-1. 채팅방에 <삭제> 대신에 <게임 초대> 버튼으로 바꿈 (호버 했을 때 초록으로 했어요)
<img width="1422" alt="스크린샷 2024-10-31 오후 11 20 27" src="https://github.com/user-attachments/assets/fbd620a5-b938-4756-8629-59b629279db1">

</br>

1-2. <게임 초대> 눌렀을 때 게임 초대 알림 갑니다!!(waitgame의 sendInvite 함수 호출해줬습니다)
다만..새로고침을 하고 버튼을 눌러야지만 알림이 갑니다
<img width="1424" alt="스크린샷 2024-10-31 오후 11 57 40" src="https://github.com/user-attachments/assets/b01ef3b0-489e-44e3-a6a4-28f9d9b5c4b4">

</br>

2. 친구 요청 여러개 와도 (실시간으로) 리스트로 잘 보이고, 수락/거절 버튼도 잘 눌림
<img width="1431" alt="스크린샷 2024-10-31 오후 11 22 15" src="https://github.com/user-attachments/assets/27b67937-6db1-4ae6-8936-04e8c42b79d8">

</br>

3. 근데 혹시 <수락/거절> 버튼에 흰색 테두리 없애는거 어떤가요?
<img width="513" alt="스크린샷 2024-10-31 오후 11 24 31" src="https://github.com/user-attachments/assets/9b31951b-2e65-4eb8-bb80-42c0498251e8">



